### PR TITLE
Added higher res sizing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "pixiv.ts",
-  "version": "0.4.5",
+  "version": "0.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.4.5",
+      "name": "pixiv.ts",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.1",


### PR DESCRIPTION
Changed the way sizing is calculated, allowing for original sizes (highest possible) to be downloaded, while maintaining the ability to use medium, large and square_medium

Also added the ability to download all pictures from a single post (PixivIllust), with the pixiv standard suffix `_p{i}`