### PR TITLE
PixivAutoCompleteV2.tags should be an array of objects instead of object

### DIFF
--- a/types/TagTypes.ts
+++ b/types/TagTypes.ts
@@ -28,5 +28,5 @@ export interface PixivAutoCompleteV2 {
   tags: {
     name: string,
     translated_name: string | null
-  }
+  }[]
 }


### PR DESCRIPTION
Btw all translate_names in each tag is null for some reason. 

Example of autocompleteV2 response (searching the word 'chino' here):
```
{
  tags: [
    { name: '香風智乃', translated_name: null },
    { name: '香風智乃生誕祭2020', translated_name: null },
    { name: '香風智乃生誕祭2019', translated_name: null },
    { name: '香風智乃生誕祭2018', translated_name: null },
    { name: '香風智乃生誕祭2021', translated_name: null },
    { name: '香風智乃生誕祭2016', translated_name: null },
    { name: '香風智乃生誕祭2017', translated_name: null },
    { name: '香風智乃生誕祭2015', translated_name: null }
  ]
}
```